### PR TITLE
feat(syntax-highlighting): add XML syntax Highlighting to XSLT stylesheet

### DIFF
--- a/src/main/resources/schemas/urn:jsonschema:io:gravitee:policy:xslt:configuration:XSLTTransformationPolicyConfiguration.json
+++ b/src/main/resources/schemas/urn:jsonschema:io:gravitee:policy:xslt:configuration:XSLTTransformationPolicyConfiguration.json
@@ -6,8 +6,15 @@
       "title": "XSLT stylesheet",
       "type" : "string",
       "x-schema-form": {
-        "type": "textarea",
-        "placeholder": "Place your XSLT stylesheet here"
+        "type": "codemirror",
+        "codemirrorOptions": {
+          "placeholder": "Place your XSLT stylesheet here or Drag&Drop your XML file",
+          "lineWrapping": true,
+          "lineNumbers": true,
+          "allowDropFileTypes": true,
+          "autoCloseTags": true,
+          "mode": "xml"
+        }	
       }
     },
     "parameters" : {


### PR DESCRIPTION
This feature add a XML syntax Highlighting to XSLT stylesheet textarea thank to angular-schema-form-codemirror

User can also Drag&Drop his XLST.XML file directly into textarea

See https://github.com/gravitee-io/gravitee-management-webui/pull/183